### PR TITLE
Add optional onParse and onDone callback functions to streams.

### DIFF
--- a/src/lib/openai/edge.ts
+++ b/src/lib/openai/edge.ts
@@ -25,6 +25,8 @@ export const OpenAI: OpenAIEdgeClient = async (
     apiKey = process.env.OPENAI_API_KEY,
     apiHeaders = {},
     controller,
+    onDone,
+    onParse
   } = {}
 ) => {
   if (!apiKey) {
@@ -64,7 +66,7 @@ export const OpenAI: OpenAIEdgeClient = async (
   }
 
   let outputStream: ReadableStream<Uint8Array>;
-  const options = { mode };
+  const options = { mode, onDone, onParse };
 
   if (shouldStream) {
     switch (mode) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -6,8 +6,7 @@ import type {
   CreateFineTuneRequest,
   CreateImageRequest,
 } from "./pinned";
-
-export type StreamMode = "raw" | "tokens";
+import { OpenAIStreamOptions } from "./streaming";
 
 export const OpenAIAPIEndpoints = {
   chat: "chat/completions",
@@ -35,7 +34,7 @@ export type OpenAICreateArgs<T extends OpenAIAPIEndpoint> =
               ? CreateChatCompletionRequest
               : never;
 
-export type OpenAIOptions = {
+export interface OpenAIOptions extends OpenAIStreamOptions {
   /**
    * By default, the API base is https://api.openai.com/v1, corresponding
    * to OpenAIs API. You can override this to use a different provider or proxy.
@@ -52,25 +51,11 @@ export type OpenAIOptions = {
    */
   apiHeaders?: Record<string, string>;
   /**
-   * Whether to return tokens or raw events.
-   */
-  mode?: StreamMode;
-  /**
    * An optional AbortController, which can be used to abort the request
    * mid-flight.
    */
   controller?: AbortController;
-  /**
-   * A function to run at the end of a stream. This is useful if you want
-   * to do something with the stream after it's done, like log token usage.
-   */
-  onDone?: () => Promise<void>;
-  /**
-   * A function that runs for each token. This is useful if you want
-   * to sum tokens used as they're returned.
-   */
-  onParse?: (token: string) => void;
-};
+}
 
 /**
  * The OpenAI API client for Edge runtime.

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -60,6 +60,16 @@ export type OpenAIOptions = {
    * mid-flight.
    */
   controller?: AbortController;
+  /**
+   * A function to run at the end of a stream. This is useful if you want
+   * to do something with the stream after it's done, like log token usage.
+   */
+  onDone?: () => Promise<void>;
+  /**
+   * A function that runs for each token. This is useful if you want
+   * to sum tokens used as they're returned.
+   */
+  onParse?: (token: string) => void;
 };
 
 /**


### PR DESCRIPTION
I wanted to kick off a few things after my stream was completed, but the package didn't have any way to pass in callbacks. This PR adds two optional functions—

* `onParse(token: string) => void` – a synchronous function, run inside a new `CallbackHandler` generator function that's added to the end of streams.
* `onDone() => Promise<void>` – an async function that's executed within `EventStream` once the stream finishes.