### PR TITLE
feat: use exponential backoff by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "openai-streams",
   "description": "Tools for working with OpenAI streams in Node.js and TypeScript.",
   "homepage": "https://github.com/SpellcraftAI/openai-streams",
-  "version": "5.5.0",
+  "version": "5.5.1-canary.0",
   "license": "MIT",
   "type": "module",
   "platform": "node",

--- a/src/lib/backoff.ts
+++ b/src/lib/backoff.ts
@@ -1,0 +1,43 @@
+/* eslint-disable no-console */
+export interface BackoffOptions {
+  maxRetries: number;
+  delay: number;
+}
+
+export const fetchWithBackoff = async (
+  input: RequestInfo,
+  init?: RequestInit,
+  { delay, maxRetries }: BackoffOptions = {
+    delay: 500,
+    maxRetries: 7
+  }
+) => {
+  for (let i = 0; i <= maxRetries; i++) {
+    try {
+      const response = await fetch(input, init);
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        if (errorData.type === "RATE_LIMIT_REACHED") {
+          throw new Error("RATE_LIMIT_REACHED");
+        }
+      }
+
+      return response;
+    } catch (error: any) {
+      if (
+        error.message === "RATE_LIMIT_REACHED" &&
+        i < maxRetries
+      ) {
+        console.log("Rate limit reached. Retrying in " + delay + "ms");
+        await new Promise((resolve) => setTimeout(resolve, delay));
+
+        delay *= 2;
+      } else {
+        throw error;
+      }
+    }
+  }
+
+  throw new Error("Max retries reached.");
+};

--- a/src/lib/openai/edge.ts
+++ b/src/lib/openai/edge.ts
@@ -1,14 +1,16 @@
 /* eslint-disable no-console */
 import { streamArray } from "yield-stream";
+
+import { OpenAIAPIEndpoints, OpenAIEdgeClient } from "../types";
 import { ENCODER } from "../../globs/shared";
 import { OpenAIError } from "../errors";
+import { fetchWithBackoff } from "../backoff";
 import {
   ChatStream,
   EventStream,
   getTokensFromResponse,
   TokenStream,
 } from "../streaming";
-import { OpenAIAPIEndpoints, OpenAIEdgeClient } from "../types";
 
 /**
  * OpenAI Edge client.
@@ -35,7 +37,7 @@ export const OpenAI: OpenAIEdgeClient = async (
 
   const shouldStream = endpoint === "completions" || endpoint === "chat";
   const path = OpenAIAPIEndpoints[endpoint];
-  const response = await fetch(`${apiBase}/${path}`, {
+  const response = await fetchWithBackoff(`${apiBase}/${path}`, {
     method: "POST",
     body: JSON.stringify({
       ...args,


### PR DESCRIPTION
Automatically handles rate-limiting. Backs off from 500ms -> 1s exponentially, max 7 retries by default.