### PR TITLE
Fix GitHub capitalisation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenAI Streams
 
-[**Github**](https://github.com/SpellcraftAI/openai-streams) |
+[**GitHub**](https://github.com/SpellcraftAI/openai-streams) |
 [**NPM**](https://npmjs.com/package/openai-streams) |
 [**Docs**](https://openai-streams.vercel.app)
 


### PR DESCRIPTION
Just a quick typo fix!