### PR TITLE
docs: update fetch option comments

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -59,8 +59,8 @@ export interface OpenAIOptions extends OpenAIStreamOptions {
    */
   controller?: AbortController;
   /**
-   * An optional fetch implementation, which can be used to replace the default global fetch call used for making
-   * API requests. This is useful in environments like node where a global fetch is not provided by default.
+   * An optional custom fetch implementation, which will be used to replace the default fetch/node-fetch
+   * call used for making API requests in edge/dom and node environments respectively.
    */
   fetch?: typeof fetch | typeof nodeFetch;
 }


### PR DESCRIPTION
Since we automatically use `node-fetch` in environments without global fetch by default now, makes sense to update the `fetch` option's comments to reflect this.